### PR TITLE
Improve password hasher compatibility and enhance security features

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+# Copilot Instructions for `unchained`
+
+`unchained` is a Go library providing password hashers compatible with
+[Django's password hashers](https://docs.djangoproject.com/en/stable/topics/auth/passwords/).
+It is used both to encode new hashes and to validate passwords from legacy or shared
+Django databases. Module path: `github.com/alexandrevicenzi/unchained`.
+
+## Build / Test
+
+- Run all tests: `go test -v ./...`
+- Run tests for a single hasher package: `go test -v ./pbkdf2`
+- Run a single test by name: `go test -v ./pbkdf2 -run TestPBKDF2SHA256`
+- Vet: `go vet ./...`
+
+There is no separate build step (library only). CI historically ran `go test -v ./...`
+across multiple Go versions (see `.travis.yml`); `go.mod` currently declares `go 1.24`.
+
+## Architecture
+
+The repo is a flat collection of subpackages, one per hash family:
+
+- `argon2/`, `bcrypt/`, `md5/`, `pbkdf2/`, `sha1/` — each implements a `*Hasher` type
+  with `Encode(password, salt, ...) (string, error)` and
+  `Verify(password, encoded) (bool, error)` methods, plus `NewXxxHasher()` constructors
+  that return Django-compatible defaults (algorithm name, iterations, sizes, etc.).
+- Top-level `unchained.go` is the public façade. It defines hasher identifier
+  constants (e.g. `PBKDF2SHA256Hasher = "pbkdf2_sha256"`), and dispatches to the
+  appropriate subpackage in `CheckPassword` / `MakePassword` based on the algorithm
+  prefix in the encoded string. `IdentifyHasher` parses that prefix.
+- `rnd.go` provides `GetRandomString` used as the default salt generator.
+
+Encoded password format follows Django: `<algorithm>$<params>$<salt>$<hash>` (argon2
+adds extra `$`-separated fields). When adding/changing a hasher, both `Encode` output
+and `Verify` parsing must stay byte-compatible with Django, and the dispatch switch
+in `unchained.go` plus `IsValidHasher` / `IsHasherImplemented` / `IsWeakHasher` lists
+must be updated together.
+
+## Conventions
+
+- Each subpackage exports its own sentinel errors (e.g. `ErrHashComponentMismatch`,
+  `ErrAlgorithmMismatch`) prefixed with `unchained/<pkg>:` in the message. Reuse this
+  pattern for new hashers rather than returning ad-hoc `errors.New`.
+- Hash comparisons use constant-time equality (`crypto/subtle.ConstantTimeCompare` or
+  `hmac.Equal`). Do not introduce plain `==` / `bytes.Equal` for hash digests.
+- `Encode` accepts `iterations int` (PBKDF2) where `<= 0` means "use the hasher's
+  default". Preserve this convention; callers (incl. `MakePassword`) rely on passing `0`.
+- `BCrypt` cannot honor a caller-supplied salt (limitation of `x/crypto/bcrypt`); the
+  `salt` parameter is intentionally ignored. Don't "fix" this.
+- Crypt is deliberately unimplemented (UNIX-only) but kept in `IsValidHasher` so
+  Django-encoded `crypt$...` strings are recognized and return `ErrHasherNotImplemented`
+  rather than `ErrInvalidHasher`. Keep this distinction when touching the dispatch.
+- Tests live alongside code as `*_test.go` in each subpackage; `example_test.go` and
+  `unchained_test.go` at the root cover the façade. Add new test vectors generated
+  from a real Django installation to guarantee compatibility.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Secure password hashers for Go that are wire-compatible with
 
 ## Install
 
-Requires Go 1.9+ (the module currently declares `go 1.24` in `go.mod`).
+Requires Go 1.24+.
 
 ```sh
 go get github.com/alexandrevicenzi/unchained
@@ -54,7 +54,7 @@ func main() {
         panic(err)
     }
     fmt.Println(encoded)
-    // pbkdf2_sha256$1000000$<salt>$<base64-hash>
+    // pbkdf2_sha256$1200000$<salt>$<base64-hash>
 
     // Verify
     ok, err := unchained.CheckPassword("my-password", encoded)
@@ -121,7 +121,7 @@ time, so no special handling is needed.
 
 ```go
 encoded, err := unchained.MakePassword("S3cret!", "", "default")
-// encoded -> pbkdf2_sha256$1000000$<salt>$<base64-hash>
+// encoded -> pbkdf2_sha256$1200000$<salt>$<base64-hash>
 // Write `encoded` directly into auth_user.password
 ```
 
@@ -149,9 +149,9 @@ has grown to **1,200,000** (5.1+). The encoded format is unchanged, so verificat
 
 ### Encode at Django 5.x's default work factor
 
-`MakePassword` defaults to `PBKDF2Hasher.Iterations = 1,000,000`, which is close
-to (but below) Django 5.1's default of **1,200,000**. To match Django 5.x exactly,
-drop down to the `pbkdf2` sub-package:
+`MakePassword` defaults to `PBKDF2Hasher.Iterations = 1,200,000`, matching
+Django 5.1+'s default. To use a different iteration count, drop down to the
+`pbkdf2` sub-package:
 
 ```go
 import (
@@ -159,14 +159,14 @@ import (
     "github.com/alexandrevicenzi/unchained/pbkdf2"
 )
 
-func encodeForDjango5(password string) (string, error) {
+func encodeWithCustomIterations(password string, iterations int) (string, error) {
     h := pbkdf2.NewPBKDF2SHA256Hasher()
     salt := unchained.GetRandomString(unchained.DefaultSaltSize)
-    return h.Encode(password, salt, 1_200_000)
+    return h.Encode(password, salt, iterations)
 }
 ```
 
-> Even hashes generated with the lower default are valid in Django 5.x —
+> Hashes generated with a lower iteration count are still valid in Django 5.x —
 > Django will accept them and re-hash to its current default on the user's next login.
 
 ### Verify a hash from a Django 5.x database
@@ -265,9 +265,9 @@ Use these directly when you need to control parameters that the top-level
 - **BCrypt** ignores the `salt` argument; bcrypt manages its own salt internally
   (limitation of `golang.org/x/crypto/bcrypt`). Encoding the same password twice
   yields different hashes — both are valid.
-- **PBKDF2 default iterations** in this library is `1,000,000`, slightly below
-  Django 5.1's current default of `1,200,000`. Use the `pbkdf2` sub-package's
-  `Encode` with an explicit `iterations` value if you need to match Django exactly.
+- **PBKDF2 default iterations** is `1,200,000`, matching Django 5.1+'s default.
+  Use the `pbkdf2` sub-package's `Encode` with an explicit `iterations` value
+  to target a different Django version.
 - **Scrypt** (Django 4.0+) is not implemented.
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -1,95 +1,346 @@
 # Unchained
 
-[![Build Status](https://travis-ci.org/alexandrevicenzi/unchained.svg?branch=master)](https://travis-ci.org/alexandrevicenzi/unchained)
-[![GoDoc](https://godoc.org/github.com/alexandrevicenzi/unchained?status.svg)](http://godoc.org/github.com/alexandrevicenzi/unchained)
+[![Go Reference](https://pkg.go.dev/badge/github.com/alexandrevicenzi/unchained.svg)](https://pkg.go.dev/github.com/alexandrevicenzi/unchained)
 [![Go Report Card](https://goreportcard.com/badge/github.com/alexandrevicenzi/unchained)](https://goreportcard.com/report/github.com/alexandrevicenzi/unchained)
+[![License: BSD-3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 
-Secure password hashers for Go compatible with [Django Password Hashers](https://docs.djangoproject.com/en/3.0/topics/auth/passwords/).
+Secure password hashers for Go that are wire-compatible with
+[Django Password Hashers](https://docs.djangoproject.com/en/stable/topics/auth/passwords/).
 
-Unchained can also be used to perform password validation against legacy or shared Django databases.
+`unchained` lets a Go service:
+
+- Generate password hashes that Django (1.x – 5.x) can validate.
+- Validate passwords stored in a legacy or shared Django database.
+
+## Table of Contents
+
+- [Install](#install)
+- [Quick Start](#quick-start)
+- [Supported Hashers](#supported-hashers)
+- [Django Compatibility Matrix](#django-compatibility-matrix)
+- [Usage with Django 1.x](#usage-with-django-1x)
+- [Usage with Django 5.x](#usage-with-django-5x)
+- [End-to-End Examples (Go ↔ Django)](#end-to-end-examples-go--django)
+- [API Reference](#api-reference)
+- [Error Reference](#error-reference)
+- [Notes & Limitations](#notes--limitations)
+- [Testing](#testing)
+- [Contributing](#contributing)
+- [License](#license)
+- [References](#references)
 
 ## Install
 
-Requires Go 1.9 or higher.
+Requires Go 1.9+ (the module currently declares `go 1.24` in `go.mod`).
 
-```
+```sh
 go get github.com/alexandrevicenzi/unchained
 ```
 
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/alexandrevicenzi/unchained"
+)
+
+func main() {
+    // Encode (default = pbkdf2_sha256, the same hasher Django uses by default)
+    encoded, err := unchained.MakePassword("my-password", "", "default")
+    if err != nil {
+        panic(err)
+    }
+    fmt.Println(encoded)
+    // pbkdf2_sha256$1000000$<salt>$<base64-hash>
+
+    // Verify
+    ok, err := unchained.CheckPassword("my-password", encoded)
+    fmt.Println(ok, err) // true <nil>
+}
+```
+
+`MakePassword(password, salt, hasher)`:
+
+- `password` — plain text. Empty string returns an unusable password (`"!" + random`).
+- `salt` — explicit salt, or empty to auto-generate via `GetRandomString(12)`. Ignored by BCrypt.
+- `hasher` — algorithm identifier (see below) or `"default"` (= `pbkdf2_sha256`).
+
+`CheckPassword(password, encoded)` auto-detects the algorithm from the encoded prefix.
+
 ## Supported Hashers
 
-| Hasher | Encode | Decode | Dependencies |
-|:-------|:------:|:------:|:------------:|
-| Argon2        | ✔ | ✔ | [golang.org/x/crypto/argon2](https://godoc.org/golang.org/x/crypto/argon2) |
-| BCrypt        | ✔ | ✔ | [golang.org/x/crypto/bcrypt](https://godoc.org/golang.org/x/crypto/bcrypt) |
-| BCrypt SHA256 | ✔ | ✔ | [golang.org/x/crypto/bcrypt](https://godoc.org/golang.org/x/crypto/bcrypt) |
-| Crypt         | ✘ | ✘ |  |
-| MD5           | ✔ | ✔ |  |
-| PBKDF2 SHA1   | ✔ | ✔ | [golang.org/x/crypto/pbkdf2](https://godoc.org/golang.org/x/crypto/pbkdf2) |
-| PBKDF2 SHA256 | ✔ | ✔ | [golang.org/x/crypto/pbkdf2](https://godoc.org/golang.org/x/crypto/pbkdf2) |
-| SHA1          | ✔ | ✔ |  |
-| Unsalted MD5  | ✔ | ✔ |  |
-| Unsalted SHA1 | ✔ | ✔ |  |
+| Hasher | Identifier | Encode | Decode | Dependencies |
+|:--|:--|:-:|:-:|:--|
+| Argon2 (argon2i + argon2id) | `argon2`        | ✅ | ✅ | [`x/crypto/argon2`](https://pkg.go.dev/golang.org/x/crypto/argon2) |
+| BCrypt                | `bcrypt`        | ✅ | ✅ | [`x/crypto/bcrypt`](https://pkg.go.dev/golang.org/x/crypto/bcrypt) |
+| BCrypt SHA256         | `bcrypt_sha256` | ✅ | ✅ | [`x/crypto/bcrypt`](https://pkg.go.dev/golang.org/x/crypto/bcrypt) |
+| Crypt                 | `crypt`         | ✘ | ✘ | — (UNIX only, not planned) |
+| MD5                   | `md5`           | ✅ | ✅ | — |
+| PBKDF2 SHA1           | `pbkdf2_sha1`   | ✅ | ✅ | [`x/crypto/pbkdf2`](https://pkg.go.dev/golang.org/x/crypto/pbkdf2) |
+| **PBKDF2 SHA256** ⭐   | `pbkdf2_sha256` | ✅ | ✅ | [`x/crypto/pbkdf2`](https://pkg.go.dev/golang.org/x/crypto/pbkdf2) |
+| SHA1                  | `sha1`          | ✅ | ✅ | — |
+| Unsalted MD5          | `unsalted_md5`  | ✅ | ✅ | — |
+| Unsalted SHA1         | `unsalted_sha1` | ✅ | ✅ | — |
+| Scrypt                | `scrypt`        | ✘ | ✘ | (Django 4.0+ only, not implemented) |
 
-## Notes
+⭐ Django's default hasher across every supported version (1.x through 5.x).
 
-Crypt support is not planned because it's UNIX only.
+## Django Compatibility Matrix
 
-BCrypt hasher does not allow to set custom salt as in Django.
-If you encode the same password multiple times you will get different hashes.
-This limitation comes from [golang.org/x/crypto/bcrypt](https://godoc.org/golang.org/x/crypto/bcrypt) library.
+The encoded format `<algorithm>$<params>$<salt>$<hash>` is identical across Django
+versions. `unchained` parses iteration counts/parameters out of the encoded string,
+so verification is independent of the iteration defaults of any specific Django version.
 
-## Examples
+| Algorithm | Django 1.x | Django 5.x | Notes |
+|---|:-:|:-:|---|
+| `pbkdf2_sha256` (default) | ✅ | ✅ | Verifies any iteration count |
+| `pbkdf2_sha1`   | ✅ | ✅ | |
+| `bcrypt`        | ✅ | ✅ | Salt argument ignored (limitation of `x/crypto/bcrypt`) |
+| `bcrypt_sha256` | ✅ | ✅ | |
+| `argon2`        | ✅ | ✅ | Both **argon2i** (Django 1.10–3.0) and **argon2id** (Django 3.1+) verified; argon2d is not supported |
+| `md5` / `sha1`  | ✅ | ✅ | Weak — verification only |
+| `unsalted_md5`  | ✅ | ✅ | Weak — verification only |
+| `unsalted_sha1` | ✅ | ⚠️ | Hasher removed from Django 5.1, but existing hashes still verify here |
+| `crypt`         | ❌ | ❌ | Not implemented; removed from Django 4.0 |
+| `scrypt`        | — | ❌ | Not implemented (Django 4.0+) |
 
-### Encode password
+> Both **argon2i** and **argon2id** encoded hashes are supported on `Verify`,
+> which auto-detects the variant from the encoded string. `MakePassword` with
+> the `"argon2"` identifier produces **argon2id** (matching Django 3.1+ defaults).
+
+## Usage with Django 1.x
+
+Django 1.x defaults to `PBKDF2PasswordHasher` (PBKDF2-SHA256). Iteration count varies
+by minor release (e.g. 1.11 → 36,000) but is parsed from the encoded string at verify
+time, so no special handling is needed.
+
+### Encode for a Django 1.x database
 
 ```go
-package main
+encoded, err := unchained.MakePassword("S3cret!", "", "default")
+// encoded -> pbkdf2_sha256$1000000$<salt>$<base64-hash>
+// Write `encoded` directly into auth_user.password
+```
 
-import "github.com/alexandrevicenzi/unchained"
+### Verify a hash from a Django 1.x database
 
-func main() {
-    hash, err := unchained.MakePassword("my-password", unchained.GetRandomString(12), "default")
+```go
+encoded := "pbkdf2_sha256$36000$JMO9TJawIXB1$5iz40fwwc+QW6lZY+TuNciua3YVMV3GXdgkhXrcvWag="
 
-    if err == nil {
-        fmt.Println(hash)
-    } else {
-        fmt.Printf("Error encoding password: %s\n", err)
-    }
+ok, err := unchained.CheckPassword("admin", encoded)
+switch {
+case err != nil:
+    fmt.Println("verification error:", err)
+case ok:
+    fmt.Println("password OK")
+default:
+    fmt.Println("password mismatch")
 }
 ```
 
-### Validate password
+## Usage with Django 5.x
+
+Django 5.x still defaults to `PBKDF2PasswordHasher`, but the default iteration count
+has grown to **1,200,000** (5.1+). The encoded format is unchanged, so verification
+"just works".
+
+### Encode at Django 5.x's default work factor
+
+`MakePassword` defaults to `PBKDF2Hasher.Iterations = 1,000,000`, which is close
+to (but below) Django 5.1's default of **1,200,000**. To match Django 5.x exactly,
+drop down to the `pbkdf2` sub-package:
 
 ```go
-package main
+import (
+    "github.com/alexandrevicenzi/unchained"
+    "github.com/alexandrevicenzi/unchained/pbkdf2"
+)
 
-import "github.com/alexandrevicenzi/unchained"
-
-func main() {
-    valid, err := unchained.CheckPassword("admin", "pbkdf2_sha256$24000$JMO9TJawIXB1$5iz40fwwc+QW6lZY+TuNciua3YVMV3GXdgkhXrcvWag=")
-
-    if valid {
-        fmt.Println("Password is valid.")
-    } else {
-        if err == nil {
-            fmt.Println("Password is invalid.")
-        } else {
-            fmt.Printf("Error decoding password: %s\n", err)
-        }
-    }
+func encodeForDjango5(password string) (string, error) {
+    h := pbkdf2.NewPBKDF2SHA256Hasher()
+    salt := unchained.GetRandomString(unchained.DefaultSaltSize)
+    return h.Encode(password, salt, 1_200_000)
 }
 ```
+
+> Even hashes generated with the lower default are valid in Django 5.x —
+> Django will accept them and re-hash to its current default on the user's next login.
+
+### Verify a hash from a Django 5.x database
+
+```go
+encoded := "pbkdf2_sha256$1200000$JMO9TJawIXB1$5iz40fwwc+QW6lZY+TuNciua3YVMV3GXdgkhXrcvWag="
+ok, err := unchained.CheckPassword("admin", encoded)
+```
+
+### Argon2id support
+
+`unchained` supports both `argon2i` and `argon2id`. `Verify` auto-detects the
+variant from the encoded string, so hashes produced by Django 3.1+ (which
+default to `argon2id`) are validated transparently. When generating new hashes
+from Go, `MakePassword(pw, "", unchained.Argon2Hasher)` produces `argon2id`
+output with Django 5.x-compatible defaults (memory=102400 KiB, time=2,
+parallelism=8). To force argon2i (legacy Django ≤ 3.0), use
+`argon2.NewArgon2iHasher()` directly.
+
+Argon2d remains unsupported — Django doesn't use it either, so this only
+matters for non-Django-generated hashes.
+
+## End-to-End Examples (Go ↔ Django)
+
+### Go encodes → Django authenticates
+
+```go
+encoded, _ := unchained.MakePassword("S3cret!", "", "default")
+db.Exec(`UPDATE auth_user SET password = $1 WHERE username = $2`, encoded, "alice")
+```
+
+```python
+# Django side
+user = authenticate(username="alice", password="S3cret!")  # ✅
+```
+
+### Django encodes → Go authenticates
+
+```python
+# Django shell
+from django.contrib.auth.hashers import make_password
+print(make_password("S3cret!"))
+# pbkdf2_sha256$1200000$xxxxxxxx$yyyyyy=
+```
+
+```go
+ok, err := unchained.CheckPassword("S3cret!", encodedFromDjango)
+```
+
+## API Reference
+
+Top-level helpers (`unchained` package):
+
+| Function | Purpose |
+|---|---|
+| `MakePassword(password, salt, hasher string) (string, error)` | Encode a password using the given hasher (or `"default"`) |
+| `CheckPassword(password, encoded string) (bool, error)`       | Verify a password against an encoded hash |
+| `IdentifyHasher(encoded string) string`                       | Return the algorithm identifier of an encoded hash |
+| `IsValidHasher(hasher string) bool`                           | True if `hasher` is one Django knows about |
+| `IsHasherImplemented(hasher string) bool`                     | True if this library can use it |
+| `IsWeakHasher(hasher string) bool`                            | True for MD5/SHA1/Crypt/Unsalted variants |
+| `IsPasswordUsable(encoded string) bool`                       | False for empty or `!`-prefixed unusable passwords |
+| `GetRandomString(n int) string`                               | Cryptographically random salt generator |
+
+Sub-packages each export a `New<Algo>Hasher()` constructor returning a typed
+hasher with `Encode` / `Verify` methods, e.g.:
+
+```go
+pbkdf2.NewPBKDF2SHA256Hasher().Encode(password, salt, iterations)
+argon2.NewArgon2Hasher().Verify(password, encoded)
+bcrypt.NewBCryptSHA256Hasher().Encode(password, "")
+```
+
+Use these directly when you need to control parameters that the top-level
+`MakePassword` doesn't expose (PBKDF2 iterations, Argon2 memory/time/threads, …).
+
+## Error Reference
+
+| Error | Meaning | Typical cause |
+|---|---|---|
+| `unchained.ErrInvalidHasher` | Unknown algorithm prefix | Corrupt or non-Django string |
+| `unchained.ErrHasherNotImplemented` | Django-known but unsupported here | `crypt`, `scrypt` |
+| `pbkdf2.ErrHashComponentMismatch` | Wrong number of `$` segments | Truncated string |
+| `pbkdf2.ErrSaltContainsDollarSign` | `$` in user-supplied salt | Use a `$`-free salt (alias `ErrSaltContainsDollarSing` retained for back-compat) |
+| `argon2.ErrAlgorithmMismatch` | Encoded prefix isn't `argon2$` | Wrong hasher dispatched |
+| `argon2.ErrUnsupportedVariant` | argon2 sub-algo is `argon2d` | argon2d isn't supported |
+| `argon2.ErrIncompatibleVersion` | argon2 version mismatch | Hash from a newer argon2 spec |
+| `(false, nil)` from `CheckPassword` | Password wrong, or `!`-prefixed unusable hash | — |
+
+## Notes & Limitations
+
+- **Crypt** is intentionally unimplemented (UNIX-only). Encoded `crypt$...` hashes
+  return `ErrHasherNotImplemented` rather than `ErrInvalidHasher`.
+- **Argon2** supports both `argon2i` and `argon2id`. `argon2d` is not supported
+  (and is not used by Django).
+- **BCrypt** ignores the `salt` argument; bcrypt manages its own salt internally
+  (limitation of `golang.org/x/crypto/bcrypt`). Encoding the same password twice
+  yields different hashes — both are valid.
+- **PBKDF2 default iterations** in this library is `1,000,000`, slightly below
+  Django 5.1's current default of `1,200,000`. Use the `pbkdf2` sub-package's
+  `Encode` with an explicit `iterations` value if you need to match Django exactly.
+- **Scrypt** (Django 4.0+) is not implemented.
+
+## Testing
+
+Run the full test suite:
+
+```sh
+go test -v ./...
+```
+
+Test a single hasher sub-package:
+
+```sh
+go test -v ./pbkdf2
+go test -v ./argon2
+```
+
+Run a specific test by name:
+
+```sh
+go test -v ./pbkdf2 -run TestPBKDF2SHA256
+```
+
+Lint the code:
+
+```sh
+go vet ./...
+```
+
+Tests are located alongside code in each sub-package (`*_test.go` files) and at the
+root (`unchained_test.go`, `example_test.go`). Most tests verify compatibility with
+hashes generated by real Django installations. When adding new hashers or modifying
+existing ones, generate fresh test vectors from Django and add them to the relevant
+test file.
+
+## Contributing
+
+Contributions are welcome! If you find a bug, want to add support for a new hasher, or
+improve documentation, please open an issue or pull request.
+
+### Before submitting a PR:
+
+1. **Add test vectors** from a real Django installation if your change involves hash
+   encoding/decoding. Include both the exact command used to generate the vector and
+   the Django version.
+2. **Run the full test suite**: `go test -v ./...`
+3. **Ensure compatibility**: Test against both legacy (Django 1.x) and modern (Django
+   5.x) hash formats.
+4. **Update documentation** if you change the public API or add a new hasher.
+
+### Guidelines:
+
+- Use constant-time equality (`crypto/subtle.ConstantTimeCompare` or `hmac.Equal`) for
+  hash comparisons — never plain `==` or `bytes.Equal`.
+- Define hasher-specific sentinel errors in the sub-package (e.g.
+  `ErrHashComponentMismatch`); prefix messages with `unchained/<pkg>:`.
+- Keep the dispatch logic in `unchained.go` in sync with the helper functions
+  (`IsValidHasher`, `IsHasherImplemented`, `IsWeakHasher`, `IdentifyHasher`).
+- BCrypt has an inherent constraint (salt argument ignored) — document this
+  clearly but don't try to "fix" it without a design discussion first.
 
 ## License
 
 BSD
 
-## Reference
+## References
 
-- [Password management in Django](https://docs.djangoproject.com/en/3.0/topics/auth/passwords/)
-- [Django Unchained](http://www.imdb.com/title/tt1853728/) :trollface:
+- [Password management in Django (stable)](https://docs.djangoproject.com/en/stable/topics/auth/passwords/)
+- [Django 1.11 password docs](https://docs.djangoproject.com/en/1.11/topics/auth/passwords/)
+- [Django 5.1 password docs](https://docs.djangoproject.com/en/5.1/topics/auth/passwords/)
+- [Django source: `django/contrib/auth/hashers.py`](https://github.com/django/django/blob/main/django/contrib/auth/hashers.py)
+- [Django Unchained](https://www.imdb.com/title/tt1853728/) :trollface:
 
 ## Related Links
 
-- [Django compatible signing for Go](https://gitlab.com/pennersr/djgo/) (`django.core.signing`)
+- [Django-compatible signing for Go (`django.core.signing`)](https://gitlab.com/pennersr/djgo/)

--- a/argon2/argon2.go
+++ b/argon2/argon2.go
@@ -16,12 +16,27 @@ var (
 	ErrHashComponentMismatch   = errors.New("unchained/argon2: hashed password components mismatch")
 	ErrAlgorithmMismatch       = errors.New("unchained/argon2: algorithm mismatch")
 	ErrIncompatibleVersion     = errors.New("unchained/argon2: incompatible version")
+	ErrUnsupportedVariant      = errors.New("unchained/argon2: unsupported argon2 variant")
 )
 
-// Argon2Hasher implements Argon2i password hasher.
+// Argon2 variants supported by Django's Argon2PasswordHasher.
+const (
+	VariantI  = "argon2i"
+	VariantID = "argon2id"
+)
+
+// Argon2Hasher implements an Argon2 password hasher compatible with
+// Django's `django.contrib.auth.hashers.Argon2PasswordHasher`.
+//
+// It supports both argon2i (Django 1.10–3.0 default) and argon2id
+// (Django 3.1+ default) variants. On Verify, the variant is auto-detected
+// from the encoded password; on Encode, the configured Variant is used.
 type Argon2Hasher struct {
-	// Algorithm identifier.
+	// Algorithm identifier (the leading prefix in the encoded password).
 	Algorithm string
+	// Variant selects which argon2 function to use on Encode.
+	// Valid values: "argon2i", "argon2id". Defaults to "argon2id".
+	Variant string
 	// Defines the amount of computation time, given in number of iterations.
 	Time uint32
 	// Defines the memory usage (KiB).
@@ -32,17 +47,36 @@ type Argon2Hasher struct {
 	Length uint32
 }
 
+func deriveKey(variant string, password, salt []byte, time, memory uint32, threads uint8, length uint32) ([]byte, error) {
+	switch variant {
+	case VariantI:
+		return argon2.Key(password, salt, time, memory, threads, length), nil
+	case VariantID:
+		return argon2.IDKey(password, salt, time, memory, threads, length), nil
+	default:
+		return nil, ErrUnsupportedVariant
+	}
+}
+
 // Encode turns a plain-text password into a hash.
 func (h *Argon2Hasher) Encode(password string, salt string) (string, error) {
+	variant := h.Variant
+	if variant == "" {
+		variant = VariantID
+	}
+
 	bSalt := []byte(salt)
-	hash := argon2.Key([]byte(password), bSalt, h.Time, h.Memory, h.Threads, h.Length)
+	hash, err := deriveKey(variant, []byte(password), bSalt, h.Time, h.Memory, h.Threads, h.Length)
+	if err != nil {
+		return "", err
+	}
 
 	b64Salt := base64.RawStdEncoding.EncodeToString(bSalt)
 	b64Hash := base64.RawStdEncoding.EncodeToString(hash)
 
 	s := fmt.Sprintf("%s$%s$v=%d$m=%d,t=%d,p=%d$%s$%s",
 		h.Algorithm,
-		"argon2i",
+		variant,
 		argon2.Version,
 		h.Memory,
 		h.Time,
@@ -62,58 +96,85 @@ func (h *Argon2Hasher) Verify(password string, encoded string) (bool, error) {
 		return false, ErrHashComponentMismatch
 	}
 
-	algorithm, method, version, params, salt, hash := s[0], s[1], s[2], s[3], s[4], s[5]
+	algorithm, variant, version, params, salt, hash := s[0], s[1], s[2], s[3], s[4], s[5]
 
-	if algorithm != h.Algorithm || method != "argon2i" {
+	if algorithm != h.Algorithm {
 		return false, ErrAlgorithmMismatch
 	}
 
-	var v int
-	var err error
-
-	_, err = fmt.Sscanf(version, "v=%d", &v)
-
-	if err != nil {
-		return false, ErrHashComponentUnreadable
+	if variant != VariantI && variant != VariantID {
+		return false, ErrUnsupportedVariant
 	}
 
+	var v int
+	if _, err := fmt.Sscanf(version, "v=%d", &v); err != nil {
+		return false, ErrHashComponentUnreadable
+	}
 	if v != argon2.Version {
 		return false, ErrIncompatibleVersion
 	}
 
 	var time, memory uint32
 	var threads uint8
-
-	_, err = fmt.Sscanf(params, "m=%d,t=%d,p=%d", &memory, &time, &threads)
-
-	if err != nil {
+	if _, err := fmt.Sscanf(params, "m=%d,t=%d,p=%d", &memory, &time, &threads); err != nil {
 		return false, ErrHashComponentUnreadable
 	}
 
 	bSalt, err := base64.RawStdEncoding.DecodeString(salt)
-
 	if err != nil {
 		return false, ErrHashComponentUnreadable
 	}
 
 	bHash, err := base64.RawStdEncoding.DecodeString(hash)
-
 	if err != nil {
 		return false, ErrHashComponentUnreadable
 	}
 
-	newHash := argon2.Key([]byte(password), bSalt, time, memory, threads, uint32(len(bHash)))
+	newHash, err := deriveKey(variant, []byte(password), bSalt, time, memory, threads, uint32(len(bHash)))
+	if err != nil {
+		return false, err
+	}
 
 	return subtle.ConstantTimeCompare(bHash, newHash) == 1, nil
 }
 
-// NewArgon2Hasher secures password hashing using the argon2 algorithm.
-func NewArgon2Hasher() *Argon2Hasher {
+// NewArgon2idHasher returns an Argon2Hasher configured to match Django's
+// current `Argon2PasswordHasher` defaults (Django 3.1+, including 5.x).
+//
+// Use this for new password hashes.
+func NewArgon2idHasher() *Argon2Hasher {
 	return &Argon2Hasher{
 		Algorithm: "argon2",
+		Variant:   VariantID,
+		Time:      2,
+		Memory:    102400, // 100 MiB, matches Django's default memory_cost
+		Threads:   8,      // matches Django's default parallelism
+		Length:    16,
+	}
+}
+
+// NewArgon2iHasher returns an Argon2Hasher configured for the legacy argon2i
+// variant used by Django 1.10 through 3.0.
+//
+// The defaults intentionally match historical Django values for backward
+// compatibility with hashes generated by older Django versions and earlier
+// versions of this library. Prefer NewArgon2idHasher for new hashes.
+func NewArgon2iHasher() *Argon2Hasher {
+	return &Argon2Hasher{
+		Algorithm: "argon2",
+		Variant:   VariantI,
 		Time:      2,
 		Memory:    512,
 		Threads:   2,
 		Length:    16,
 	}
+}
+
+// NewArgon2Hasher is a backward-compatible alias for NewArgon2iHasher.
+//
+// Deprecated: Use NewArgon2idHasher for new code (matches Django 3.1+).
+// This constructor is preserved so existing callers continue to produce
+// the legacy argon2i format with the original (weak) defaults.
+func NewArgon2Hasher() *Argon2Hasher {
+	return NewArgon2iHasher()
 }

--- a/argon2/argon2_errors_test.go
+++ b/argon2/argon2_errors_test.go
@@ -1,0 +1,94 @@
+package argon2
+
+import "testing"
+
+func TestArgon2VerifyComponentMismatch(t *testing.T) {
+	_, err := NewArgon2idHasher().Verify("admin", "argon2$too$few$parts")
+	if err != ErrHashComponentMismatch {
+		t.Errorf("Expected ErrHashComponentMismatch, got: %v", err)
+	}
+}
+
+func TestArgon2VerifyAlgorithmMismatch(t *testing.T) {
+	// Six parts, but leading prefix isn't "argon2".
+	_, err := NewArgon2idHasher().Verify("admin", "scrypt$argon2id$v=19$m=1,t=1,p=1$AAAA$AAAA")
+	if err != ErrAlgorithmMismatch {
+		t.Errorf("Expected ErrAlgorithmMismatch, got: %v", err)
+	}
+}
+
+func TestArgon2VerifyUnreadableVersion(t *testing.T) {
+	_, err := NewArgon2idHasher().Verify("admin", "argon2$argon2id$bogus$m=1,t=1,p=1$AAAA$AAAA")
+	if err != ErrHashComponentUnreadable {
+		t.Errorf("Expected ErrHashComponentUnreadable, got: %v", err)
+	}
+}
+
+func TestArgon2VerifyIncompatibleVersion(t *testing.T) {
+	_, err := NewArgon2idHasher().Verify("admin", "argon2$argon2id$v=99$m=1,t=1,p=1$AAAA$AAAA")
+	if err != ErrIncompatibleVersion {
+		t.Errorf("Expected ErrIncompatibleVersion, got: %v", err)
+	}
+}
+
+func TestArgon2VerifyUnreadableParams(t *testing.T) {
+	_, err := NewArgon2idHasher().Verify("admin", "argon2$argon2id$v=19$bogus$AAAA$AAAA")
+	if err != ErrHashComponentUnreadable {
+		t.Errorf("Expected ErrHashComponentUnreadable, got: %v", err)
+	}
+}
+
+func TestArgon2VerifyUnreadableSalt(t *testing.T) {
+	_, err := NewArgon2idHasher().Verify("admin", "argon2$argon2id$v=19$m=1,t=1,p=1$!!!notbase64!!!$AAAA")
+	if err != ErrHashComponentUnreadable {
+		t.Errorf("Expected ErrHashComponentUnreadable, got: %v", err)
+	}
+}
+
+func TestArgon2VerifyUnreadableHash(t *testing.T) {
+	_, err := NewArgon2idHasher().Verify("admin", "argon2$argon2id$v=19$m=1,t=1,p=1$AAAA$!!!notbase64!!!")
+	if err != ErrHashComponentUnreadable {
+		t.Errorf("Expected ErrHashComponentUnreadable, got: %v", err)
+	}
+}
+
+func TestArgon2EncodeWithEmptyVariantDefaultsToArgon2id(t *testing.T) {
+	h := &Argon2Hasher{
+		Algorithm: "argon2",
+		Variant:   "", // unset → should default to argon2id
+		Time:      1,
+		Memory:    8192,
+		Threads:   1,
+		Length:    16,
+	}
+	encoded, err := h.Encode("admin", "abcdefghijkl")
+	if err != nil {
+		t.Fatalf("Encode error: %s", err)
+	}
+	const want = "argon2$argon2id$"
+	if len(encoded) < len(want) || encoded[:len(want)] != want {
+		t.Errorf("Expected default variant argon2id, got: %s", encoded)
+	}
+}
+
+func TestArgon2EncodeRejectsUnsupportedVariant(t *testing.T) {
+	h := &Argon2Hasher{
+		Algorithm: "argon2",
+		Variant:   "argon2d",
+		Time:      1,
+		Memory:    8192,
+		Threads:   1,
+		Length:    16,
+	}
+	_, err := h.Encode("admin", "salt")
+	if err != ErrUnsupportedVariant {
+		t.Errorf("Expected ErrUnsupportedVariant, got: %v", err)
+	}
+}
+
+func TestNewArgon2HasherIsArgon2iAlias(t *testing.T) {
+	h := NewArgon2Hasher()
+	if h.Variant != VariantI {
+		t.Errorf("NewArgon2Hasher (deprecated) should remain argon2i, got %q", h.Variant)
+	}
+}

--- a/argon2/argon2_test.go
+++ b/argon2/argon2_test.go
@@ -1,6 +1,7 @@
 package argon2
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -117,5 +118,56 @@ func TestArgon2VerifyInvalidPassword(t *testing.T) {
 
 	if valid {
 		t.Fatal("Password should not be valid.")
+	}
+}
+
+func TestArgon2idEncodeAndVerifyRoundTrip(t *testing.T) {
+	h := NewArgon2idHasher()
+	// Use weaker params for the test to keep CI fast.
+	h.Memory = 8192
+	h.Threads = 1
+	h.Time = 1
+
+	encoded, err := h.Encode("hello-world", "abcdefghijkl")
+	if err != nil {
+		t.Fatalf("Encode error: %s", err)
+	}
+	if !strings.HasPrefix(encoded, "argon2$argon2id$v=19$") {
+		t.Fatalf("Expected argon2id prefix, got: %s", encoded)
+	}
+
+	valid, err := h.Verify("hello-world", encoded)
+	if err != nil {
+		t.Fatalf("Verify error: %s", err)
+	}
+	if !valid {
+		t.Fatal("Password should be valid.")
+	}
+
+	valid, err = h.Verify("wrong-password", encoded)
+	if err != nil {
+		t.Fatalf("Verify error: %s", err)
+	}
+	if valid {
+		t.Fatal("Password should not be valid.")
+	}
+}
+
+func TestArgon2idHasherVerifiesArgon2iHash(t *testing.T) {
+	// Verify is variant-agnostic: argon2id hasher should validate an argon2i
+	// hash because the variant is auto-detected from the encoded string.
+	valid, err := NewArgon2idHasher().Verify("admin", "argon2$argon2i$v=19$m=512,t=2,p=2$NnFZNGxmQTE1bmFV$kPPGrqD6dnRllcQeksFN+w")
+	if err != nil {
+		t.Fatalf("Verify error: %s", err)
+	}
+	if !valid {
+		t.Fatal("Password should be valid.")
+	}
+}
+
+func TestArgon2VerifyUnsupportedVariant(t *testing.T) {
+	_, err := NewArgon2Hasher().Verify("admin", "argon2$argon2d$v=19$m=512,t=2,p=2$NnFZNGxmQTE1bmFV$kPPGrqD6dnRllcQeksFN+w")
+	if err != ErrUnsupportedVariant {
+		t.Fatalf("Expected ErrUnsupportedVariant, got: %v", err)
 	}
 }

--- a/bcrypt/bcrypt.go
+++ b/bcrypt/bcrypt.go
@@ -67,7 +67,13 @@ func (h *BCryptHasher) Verify(password string, encoded string) (bool, error) {
 	}
 
 	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
-	return err == nil, nil
+	if err == bcrypt.ErrMismatchedHashAndPassword {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 // NewBCryptHasher secures password hashing using the bcrypt algorithm.

--- a/bcrypt/bcrypt_test.go
+++ b/bcrypt/bcrypt_test.go
@@ -148,3 +148,21 @@ func TestBCryptSHA265VerifyInvalidPassword(t *testing.T) {
 		t.Fatal("Password should not be valid.")
 	}
 }
+
+func TestBCryptVerifyMalformedHashReturnsError(t *testing.T) {
+	// A malformed bcrypt blob (wrong segment count, garbage cost) must surface
+	// as a non-nil error rather than be silently swallowed as "password mismatch".
+	_, err := NewBCryptHasher().Verify("admin", "bcrypt$$this-is-not-a-bcrypt-hash")
+	if err == nil {
+		t.Fatal("Expected error for malformed bcrypt hash, got nil")
+	}
+}
+
+func TestBCryptVerifyAlgorithmMismatch(t *testing.T) {
+	// Passing a bcrypt_sha256-formatted hash to a plain bcrypt hasher should
+	// flag the mismatch up front.
+	_, err := NewBCryptHasher().Verify("admin", "bcrypt_sha256$$2b$12$WZK9cb9qKN.Q5LCYPq/gj.6gvry1b37HUsJER6KhQBnIWmPyyaaqi")
+	if err != ErrAlgorithmMismatch {
+		t.Fatalf("Expected ErrAlgorithmMismatch, got: %v", err)
+	}
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,177 @@
+package unchained
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/alexandrevicenzi/unchained/argon2"
+	"github.com/alexandrevicenzi/unchained/pbkdf2"
+)
+
+func TestIsValidHasher(t *testing.T) {
+	valid := []string{
+		Argon2Hasher, BCryptHasher, BCryptSHA256Hasher, CryptHasher,
+		MD5Hasher, PBKDF2SHA1Hasher, PBKDF2SHA256Hasher, SHA1Hasher,
+		UnsaltedMD5Hasher, UnsaltedSHA1Hasher,
+	}
+	for _, h := range valid {
+		if !IsValidHasher(h) {
+			t.Errorf("IsValidHasher(%q) = false, want true", h)
+		}
+	}
+
+	invalid := []string{"", "scrypt", "unknown", "pbkdf2"}
+	for _, h := range invalid {
+		if IsValidHasher(h) {
+			t.Errorf("IsValidHasher(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestIsWeakHasher(t *testing.T) {
+	weak := []string{CryptHasher, MD5Hasher, SHA1Hasher, UnsaltedMD5Hasher, UnsaltedSHA1Hasher}
+	for _, h := range weak {
+		if !IsWeakHasher(h) {
+			t.Errorf("IsWeakHasher(%q) = false, want true", h)
+		}
+	}
+
+	strong := []string{Argon2Hasher, BCryptHasher, BCryptSHA256Hasher, PBKDF2SHA1Hasher, PBKDF2SHA256Hasher}
+	for _, h := range strong {
+		if IsWeakHasher(h) {
+			t.Errorf("IsWeakHasher(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestIsHasherImplemented(t *testing.T) {
+	implemented := []string{
+		Argon2Hasher, BCryptHasher, BCryptSHA256Hasher, MD5Hasher,
+		PBKDF2SHA1Hasher, PBKDF2SHA256Hasher, SHA1Hasher,
+		UnsaltedMD5Hasher, UnsaltedSHA1Hasher,
+	}
+	for _, h := range implemented {
+		if !IsHasherImplemented(h) {
+			t.Errorf("IsHasherImplemented(%q) = false, want true", h)
+		}
+	}
+
+	notImplemented := []string{CryptHasher, "scrypt", "unknown"}
+	for _, h := range notImplemented {
+		if IsHasherImplemented(h) {
+			t.Errorf("IsHasherImplemented(%q) = true, want false", h)
+		}
+	}
+}
+
+func TestIdentifyHasherEdgeCases(t *testing.T) {
+	cases := map[string]string{
+		// 32-char hex with no $ → unsalted_md5
+		"21232f297a57a5a743894a0e4a801fc3": UnsaltedMD5Hasher,
+		// "md5$$<32-hex>" prefix-form unsalted_md5 (37 chars)
+		"md5$$21232f297a57a5a743894a0e4a801fc3": UnsaltedMD5Hasher,
+		// "sha1$$<40-hex>" prefix-form unsalted_sha1 (46 chars)
+		"sha1$$d033e22ae348aeb5660fc2140aec35850c4da997": UnsaltedSHA1Hasher,
+		// Generic prefix split
+		"pbkdf2_sha256$1000$abc$def": PBKDF2SHA256Hasher,
+		"argon2$argon2id$v=19$m=1$t=1$p=1$AAAA$AAAA": Argon2Hasher,
+	}
+	for encoded, want := range cases {
+		if got := IdentifyHasher(encoded); got != want {
+			t.Errorf("IdentifyHasher(%q) = %q, want %q", encoded, got, want)
+		}
+	}
+}
+
+func TestMakePasswordEmptyPasswordReturnsUnusable(t *testing.T) {
+	encoded, err := MakePassword("", "salt", "default")
+	if err != nil {
+		t.Fatalf("MakePassword error: %s", err)
+	}
+	if !strings.HasPrefix(encoded, UnusablePasswordPrefix) {
+		t.Errorf("Expected unusable prefix, got: %s", encoded)
+	}
+	if len(encoded) != len(UnusablePasswordPrefix)+UnusablePasswordSuffixLength {
+		t.Errorf("Unusable password has wrong length: %d", len(encoded))
+	}
+	if IsPasswordUsable(encoded) {
+		t.Errorf("Generated unusable password should not be usable")
+	}
+}
+
+func TestMakePasswordInvalidHasher(t *testing.T) {
+	_, err := MakePassword("admin", "salt", "totally-fake-hasher")
+	if err != ErrInvalidHasher {
+		t.Errorf("Expected ErrInvalidHasher, got: %v", err)
+	}
+}
+
+func TestMakePasswordHasherNotImplemented(t *testing.T) {
+	_, err := MakePassword("admin", "salt", CryptHasher)
+	if err != ErrHasherNotImplemented {
+		t.Errorf("Expected ErrHasherNotImplemented, got: %v", err)
+	}
+}
+
+func TestCheckPasswordInvalidHasher(t *testing.T) {
+	_, err := CheckPassword("admin", "totally-fake-hasher$abc$def")
+	if err != ErrInvalidHasher {
+		t.Errorf("Expected ErrInvalidHasher, got: %v", err)
+	}
+}
+
+func TestCheckPasswordHasherNotImplemented(t *testing.T) {
+	_, err := CheckPassword("admin", "crypt$abc$def")
+	if err != ErrHasherNotImplemented {
+		t.Errorf("Expected ErrHasherNotImplemented, got: %v", err)
+	}
+}
+
+func TestCheckPasswordUnusable(t *testing.T) {
+	valid, err := CheckPassword("admin", "!unusable")
+	if err != nil {
+		t.Fatalf("CheckPassword error: %s", err)
+	}
+	if valid {
+		t.Errorf("Unusable password should never validate")
+	}
+
+	valid, err = CheckPassword("admin", "")
+	if err != nil {
+		t.Fatalf("CheckPassword error: %s", err)
+	}
+	if valid {
+		t.Errorf("Empty password should never validate")
+	}
+}
+
+func TestCheckPasswordPropagatesArgon2Error(t *testing.T) {
+	// Truncated argon2 hash — the inner hasher's ErrHashComponentMismatch
+	// must surface through CheckPassword instead of being swallowed.
+	_, err := CheckPassword("admin", "argon2$argon2id$v=19$m=1,t=1,p=1")
+	if err != argon2.ErrHashComponentMismatch {
+		t.Errorf("Expected argon2.ErrHashComponentMismatch, got: %v", err)
+	}
+}
+
+func TestCheckPasswordPropagatesPBKDF2Error(t *testing.T) {
+	// Truncated pbkdf2 hash — pbkdf2.ErrHashComponentMismatch must surface.
+	_, err := CheckPassword("admin", "pbkdf2_sha256$1000$saltonly")
+	if err != pbkdf2.ErrHashComponentMismatch {
+		t.Errorf("Expected pbkdf2.ErrHashComponentMismatch, got: %v", err)
+	}
+}
+
+func TestCheckPasswordWrongPasswordReturnsFalse(t *testing.T) {
+	encoded, err := MakePassword("right-password", "saltsaltsalt", "default")
+	if err != nil {
+		t.Fatalf("MakePassword error: %s", err)
+	}
+	valid, err := CheckPassword("wrong-password", encoded)
+	if err != nil {
+		t.Fatalf("CheckPassword error: %s", err)
+	}
+	if valid {
+		t.Errorf("Wrong password should not validate")
+	}
+}

--- a/md5/md5.go
+++ b/md5/md5.go
@@ -13,8 +13,14 @@ import (
 var (
 	ErrHashComponentMismatch  = errors.New("unchained/md5: hashed password components mismatch")
 	ErrAlgorithmMismatch      = errors.New("unchained/md5: algorithm mismatch")
-	ErrSaltContainsDollarSing = errors.New("unchained/md5: salt contains dollar sign ($)")
+	ErrSaltContainsDollarSign = errors.New("unchained/md5: salt contains dollar sign ($)")
 	ErrSaltIsEmpty            = errors.New("unchained/md5: salt is empty")
+
+	// ErrSaltContainsDollarSing is a backwards-compatible alias preserved
+	// because the original symbol was misspelled.
+	//
+	// Deprecated: use ErrSaltContainsDollarSign.
+	ErrSaltContainsDollarSing = ErrSaltContainsDollarSign
 )
 
 // UnsaltedMD5PasswordHasher implements a simple MD5 password hasher.
@@ -58,7 +64,7 @@ func (h *MD5PasswordHasher) Encode(password string, salt string) (string, error)
 	}
 
 	if strings.Contains(salt, "$") {
-		return "", ErrSaltContainsDollarSing
+		return "", ErrSaltContainsDollarSign
 	}
 
 	hasher := md5.New()

--- a/md5/md5_errors_test.go
+++ b/md5/md5_errors_test.go
@@ -1,0 +1,48 @@
+package md5
+
+import "testing"
+
+func TestMD5EncodeRejectsEmptySalt(t *testing.T) {
+	_, err := NewMD5PasswordHasher().Encode("admin", "")
+	if err != ErrSaltIsEmpty {
+		t.Errorf("Expected ErrSaltIsEmpty, got: %v", err)
+	}
+}
+
+func TestMD5EncodeRejectsDollarSaltSign(t *testing.T) {
+	_, err := NewMD5PasswordHasher().Encode("admin", "bad$salt")
+	if err != ErrSaltContainsDollarSign {
+		t.Errorf("Expected ErrSaltContainsDollarSign, got: %v", err)
+	}
+}
+
+func TestMD5VerifyComponentMismatch(t *testing.T) {
+	_, err := NewMD5PasswordHasher().Verify("admin", "md5$saltonly")
+	if err != ErrHashComponentMismatch {
+		t.Errorf("Expected ErrHashComponentMismatch, got: %v", err)
+	}
+}
+
+func TestMD5VerifyAlgorithmMismatch(t *testing.T) {
+	_, err := NewMD5PasswordHasher().Verify("admin", "sha1$salt$abc")
+	if err != ErrAlgorithmMismatch {
+		t.Errorf("Expected ErrAlgorithmMismatch, got: %v", err)
+	}
+}
+
+func TestUnsaltedMD5VerifyMD5PrefixForm(t *testing.T) {
+	// "md5$$<32-hex>" prefix form should validate as if it were the bare hash.
+	valid, err := NewUnsaltedMD5PasswordHasher().Verify("admin", "md5$$21232f297a57a5a743894a0e4a801fc3")
+	if err != nil {
+		t.Fatalf("Verify error: %s", err)
+	}
+	if !valid {
+		t.Error("Password should be valid in md5$$<hex> prefix form")
+	}
+}
+
+func TestMD5DeprecatedAliasMatches(t *testing.T) {
+	if ErrSaltContainsDollarSing != ErrSaltContainsDollarSign {
+		t.Error("Deprecated alias must point at the canonical error")
+	}
+}

--- a/pbkdf2/pbkdf2.go
+++ b/pbkdf2/pbkdf2.go
@@ -19,7 +19,13 @@ var (
 	ErrHashComponentUnreadable = errors.New("unchained/pbkdf2: unreadable component in hashed password")
 	ErrHashComponentMismatch   = errors.New("unchained/pbkdf2: hashed password components mismatch")
 	ErrAlgorithmMismatch       = errors.New("unchained/pbkdf2: algorithm mismatch")
-	ErrSaltContainsDollarSing  = errors.New("unchained/pbkdf2: salt contains dollar sign ($)")
+	ErrSaltContainsDollarSign  = errors.New("unchained/pbkdf2: salt contains dollar sign ($)")
+
+	// ErrSaltContainsDollarSing is a backwards-compatible alias preserved
+	// because the original symbol was misspelled.
+	//
+	// Deprecated: use ErrSaltContainsDollarSign.
+	ErrSaltContainsDollarSing = ErrSaltContainsDollarSign
 )
 
 // PBKDF2Hasher implements PBKDF2 password hasher.
@@ -37,7 +43,7 @@ type PBKDF2Hasher struct {
 // Encode turns a plain-text password into a hash.
 func (h *PBKDF2Hasher) Encode(password string, salt string, iterations int) (string, error) {
 	if strings.Contains(salt, "$") {
-		return "", ErrSaltContainsDollarSing
+		return "", ErrSaltContainsDollarSign
 	}
 
 	if iterations <= 0 {
@@ -85,10 +91,12 @@ func (h *PBKDF2Hasher) Verify(password string, encoded string) (bool, error) {
 //
 // This is compatible with other implementations of PBKDF2,
 // such as openssl's PKCS5_PBKDF2_HMAC_SHA1().
+//
+// Iterations default matches Django 5.x's PBKDF2PasswordHasher.
 func NewPBKDF2SHA1Hasher() *PBKDF2Hasher {
 	return &PBKDF2Hasher{
 		Algorithm:  "pbkdf2_sha1",
-		Iterations: 216000,
+		Iterations: 1000000,
 		Size:       sha1.Size,
 		Digest:     sha1.New,
 	}
@@ -98,10 +106,12 @@ func NewPBKDF2SHA1Hasher() *PBKDF2Hasher {
 //
 // Configured to use PBKDF2 + HMAC + SHA256.
 // The result is a 64 byte binary string.
+//
+// Iterations default matches Django 5.x's PBKDF2PasswordHasher.
 func NewPBKDF2SHA256Hasher() *PBKDF2Hasher {
 	return &PBKDF2Hasher{
 		Algorithm:  "pbkdf2_sha256",
-		Iterations: 216000,
+		Iterations: 1000000,
 		Size:       sha256.Size,
 		Digest:     sha256.New,
 	}

--- a/pbkdf2/pbkdf2.go
+++ b/pbkdf2/pbkdf2.go
@@ -96,7 +96,7 @@ func (h *PBKDF2Hasher) Verify(password string, encoded string) (bool, error) {
 func NewPBKDF2SHA1Hasher() *PBKDF2Hasher {
 	return &PBKDF2Hasher{
 		Algorithm:  "pbkdf2_sha1",
-		Iterations: 1000000,
+		Iterations: 1_200_000,
 		Size:       sha1.Size,
 		Digest:     sha1.New,
 	}
@@ -105,13 +105,13 @@ func NewPBKDF2SHA1Hasher() *PBKDF2Hasher {
 // NewPBKDF2SHA256Hasher secures password hashing using the PBKDF2 algorithm.
 //
 // Configured to use PBKDF2 + HMAC + SHA256.
-// The result is a 64 byte binary string.
+// The result is a 32 byte binary string.
 //
 // Iterations default matches Django 5.x's PBKDF2PasswordHasher.
 func NewPBKDF2SHA256Hasher() *PBKDF2Hasher {
 	return &PBKDF2Hasher{
 		Algorithm:  "pbkdf2_sha256",
-		Iterations: 1000000,
+		Iterations: 1_200_000,
 		Size:       sha256.Size,
 		Digest:     sha256.New,
 	}

--- a/pbkdf2/pbkdf2_errors_test.go
+++ b/pbkdf2/pbkdf2_errors_test.go
@@ -1,0 +1,68 @@
+package pbkdf2
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPBKDF2EncodeRejectsDollarSaltSign(t *testing.T) {
+	_, err := NewPBKDF2SHA256Hasher().Encode("admin", "bad$salt", 1000)
+	if err != ErrSaltContainsDollarSign {
+		t.Errorf("Expected ErrSaltContainsDollarSign, got: %v", err)
+	}
+}
+
+func TestPBKDF2EncodeUsesDefaultIterationsWhenZero(t *testing.T) {
+	h := NewPBKDF2SHA256Hasher()
+	h.Iterations = 1234
+	encoded, err := h.Encode("admin", "salt", 0)
+	if err != nil {
+		t.Fatalf("Encode error: %s", err)
+	}
+	if !strings.HasPrefix(encoded, "pbkdf2_sha256$1234$salt$") {
+		t.Errorf("Expected default iterations to be used, got: %s", encoded)
+	}
+}
+
+func TestPBKDF2VerifyComponentMismatch(t *testing.T) {
+	_, err := NewPBKDF2SHA256Hasher().Verify("admin", "pbkdf2_sha256$1000$saltonly")
+	if err != ErrHashComponentMismatch {
+		t.Errorf("Expected ErrHashComponentMismatch, got: %v", err)
+	}
+}
+
+func TestPBKDF2VerifyAlgorithmMismatch(t *testing.T) {
+	// SHA256 hasher fed a SHA1-encoded hash should refuse it.
+	_, err := NewPBKDF2SHA256Hasher().Verify("admin", "pbkdf2_sha1$1000$salt$ZmFrZWhhc2g=")
+	if err != ErrAlgorithmMismatch {
+		t.Errorf("Expected ErrAlgorithmMismatch, got: %v", err)
+	}
+}
+
+func TestPBKDF2VerifyUnreadableIterations(t *testing.T) {
+	_, err := NewPBKDF2SHA256Hasher().Verify("admin", "pbkdf2_sha256$notanumber$salt$ZmFrZQ==")
+	if err != ErrHashComponentUnreadable {
+		t.Errorf("Expected ErrHashComponentUnreadable, got: %v", err)
+	}
+}
+
+func TestPBKDF2DeprecatedAliasMatches(t *testing.T) {
+	if ErrSaltContainsDollarSing != ErrSaltContainsDollarSign {
+		t.Error("Deprecated alias must point at the canonical error")
+	}
+}
+
+func TestPBKDF2WrongPasswordReturnsFalse(t *testing.T) {
+	h := NewPBKDF2SHA256Hasher()
+	encoded, err := h.Encode("right", "saltvalue", 1000)
+	if err != nil {
+		t.Fatalf("Encode error: %s", err)
+	}
+	valid, err := h.Verify("wrong", encoded)
+	if err != nil {
+		t.Fatalf("Verify error: %s", err)
+	}
+	if valid {
+		t.Error("Wrong password should not validate")
+	}
+}

--- a/rnd.go
+++ b/rnd.go
@@ -3,6 +3,7 @@ package unchained
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"math"
 )
 
 const allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -19,13 +20,9 @@ func GetRandomString(length int) string {
 	}
 
 	n := uint32(len(allowedChars))
-	// Threshold for unbiased rejection sampling: discard any uint32 value
-	// that would cause modulo bias.
-	maxAcceptable := (uint32(1<<32-1)/n)*n + n
-	if maxAcceptable < n {
-		// Overflowed (n is a power of two divisor of 2^32); no bias possible.
-		maxAcceptable = 0
-	}
+	// Rejection-sampling threshold: accept only values in [0, maxAcceptable)
+	// so the accepted range is exactly divisible by n (zero modulo bias).
+	maxAcceptable := (math.MaxUint32 / n) * n
 
 	out := make([]byte, length)
 	// 4 bytes per character, with a generous overhead for rejection.
@@ -49,7 +46,7 @@ func GetRandomString(length int) string {
 		}
 		v := binary.LittleEndian.Uint32(buf[bufIdx:])
 		bufIdx += 4
-		if maxAcceptable == 0 || v < maxAcceptable {
+		if v < maxAcceptable {
 			out[pos] = allowedChars[v%n]
 			pos++
 		}

--- a/rnd.go
+++ b/rnd.go
@@ -1,44 +1,58 @@
 package unchained
 
 import (
-	crand "crypto/rand"
-	"math/big"
-	"math/rand"
+	"crypto/rand"
+	"encoding/binary"
 )
 
-const (
-	allowedChars     = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	allowedCharsSize = len(allowedChars)
-	maxInt           = 1<<63 - 1
-)
+const allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
-type source struct{}
-
-func (s *source) Int63() int64 {
-	return int64(s.Uint64() & ^uint64(1<<63))
-}
-
-func (s *source) Uint64() uint64 {
-	i, err := crand.Int(crand.Reader, big.NewInt(maxInt))
-
-	if err != nil {
-		panic(err)
-	}
-
-	return i.Uint64()
-}
-
-func (s *source) Seed(seed int64) {}
-
-// GetRandomString returns a securely generated random string.
+// GetRandomString returns a cryptographically secure random string of the
+// given length composed of characters from [a-zA-Z0-9].
+//
+// It panics if the system's secure random source is unavailable, mirroring
+// Go's stdlib convention for cryptographic primitives whose failure is
+// effectively unrecoverable.
 func GetRandomString(length int) string {
-	b := make([]byte, length)
-	rnd := rand.New(&source{})
-
-	for i := range b {
-		c := rnd.Intn(allowedCharsSize)
-		b[i] = allowedChars[c]
+	if length <= 0 {
+		return ""
 	}
 
-	return string(b)
+	n := uint32(len(allowedChars))
+	// Threshold for unbiased rejection sampling: discard any uint32 value
+	// that would cause modulo bias.
+	maxAcceptable := (uint32(1<<32-1)/n)*n + n
+	if maxAcceptable < n {
+		// Overflowed (n is a power of two divisor of 2^32); no bias possible.
+		maxAcceptable = 0
+	}
+
+	out := make([]byte, length)
+	// 4 bytes per character, with a generous overhead for rejection.
+	bufSize := length * 8
+	if bufSize < 32 {
+		bufSize = 32
+	}
+	buf := make([]byte, bufSize)
+
+	if _, err := rand.Read(buf); err != nil {
+		panic("unchained: crypto/rand read failed: " + err.Error())
+	}
+
+	pos, bufIdx := 0, 0
+	for pos < length {
+		if bufIdx+4 > len(buf) {
+			if _, err := rand.Read(buf); err != nil {
+				panic("unchained: crypto/rand read failed: " + err.Error())
+			}
+			bufIdx = 0
+		}
+		v := binary.LittleEndian.Uint32(buf[bufIdx:])
+		bufIdx += 4
+		if maxAcceptable == 0 || v < maxAcceptable {
+			out[pos] = allowedChars[v%n]
+			pos++
+		}
+	}
+	return string(out)
 }

--- a/rnd_test.go
+++ b/rnd_test.go
@@ -1,0 +1,35 @@
+package unchained
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetRandomStringLength(t *testing.T) {
+	for _, n := range []int{0, 1, 12, 40, 64, 128} {
+		s := GetRandomString(n)
+		if len(s) != n {
+			t.Errorf("GetRandomString(%d) returned length %d", n, len(s))
+		}
+	}
+}
+
+func TestGetRandomStringCharset(t *testing.T) {
+	s := GetRandomString(1024)
+	for i, r := range s {
+		if !strings.ContainsRune(allowedChars, r) {
+			t.Fatalf("GetRandomString produced disallowed character %q at index %d", r, i)
+		}
+	}
+}
+
+func TestGetRandomStringUniqueness(t *testing.T) {
+	// Two consecutive 24-char strings should virtually never collide;
+	// the previous implementation reseeded math/rand from crypto/rand
+	// per call, so this also guards against a regression of that pattern.
+	a := GetRandomString(24)
+	b := GetRandomString(24)
+	if a == b {
+		t.Fatalf("GetRandomString returned identical consecutive values: %q", a)
+	}
+}

--- a/sha1/sha1.go
+++ b/sha1/sha1.go
@@ -13,8 +13,14 @@ import (
 var (
 	ErrHashComponentMismatch  = errors.New("unchained/sha1: hashed password components mismatch")
 	ErrAlgorithmMismatch      = errors.New("unchained/sha1: algorithm mismatch")
-	ErrSaltContainsDollarSing = errors.New("unchained/sha1: salt contains dollar sign ($)")
+	ErrSaltContainsDollarSign = errors.New("unchained/sha1: salt contains dollar sign ($)")
 	ErrSaltIsEmpty            = errors.New("unchained/sha1: salt is empty")
+
+	// ErrSaltContainsDollarSing is a backwards-compatible alias preserved
+	// because the original symbol was misspelled.
+	//
+	// Deprecated: use ErrSaltContainsDollarSign.
+	ErrSaltContainsDollarSing = ErrSaltContainsDollarSign
 )
 
 // SHA1PasswordHasher implements Salted SHA1 password hasher.
@@ -33,7 +39,7 @@ func (h *SHA1PasswordHasher) Encode(password string, salt string) (string, error
 		}
 
 		if strings.Contains(salt, "$") {
-			return "", ErrSaltContainsDollarSing
+			return "", ErrSaltContainsDollarSign
 		}
 	} else {
 		salt = ""

--- a/sha1/sha1_errors_test.go
+++ b/sha1/sha1_errors_test.go
@@ -1,0 +1,49 @@
+package sha1
+
+import "testing"
+
+func TestSHA1EncodeRejectsEmptySalt(t *testing.T) {
+	_, err := NewSHA1PasswordHasher().Encode("admin", "")
+	if err != ErrSaltIsEmpty {
+		t.Errorf("Expected ErrSaltIsEmpty, got: %v", err)
+	}
+}
+
+func TestSHA1EncodeRejectsDollarSaltSign(t *testing.T) {
+	_, err := NewSHA1PasswordHasher().Encode("admin", "bad$salt")
+	if err != ErrSaltContainsDollarSign {
+		t.Errorf("Expected ErrSaltContainsDollarSign, got: %v", err)
+	}
+}
+
+func TestSHA1VerifyComponentMismatch(t *testing.T) {
+	_, err := NewSHA1PasswordHasher().Verify("admin", "sha1$saltonly")
+	if err != ErrHashComponentMismatch {
+		t.Errorf("Expected ErrHashComponentMismatch, got: %v", err)
+	}
+}
+
+func TestSHA1VerifyAlgorithmMismatch(t *testing.T) {
+	_, err := NewSHA1PasswordHasher().Verify("admin", "md5$salt$abc")
+	if err != ErrAlgorithmMismatch {
+		t.Errorf("Expected ErrAlgorithmMismatch, got: %v", err)
+	}
+}
+
+func TestUnsaltedSHA1Encode(t *testing.T) {
+	// Salted == false branch: salt parameter must be ignored.
+	encoded, err := NewUnsaltedSHA1PasswordHasher().Encode("admin", "ignored")
+	if err != nil {
+		t.Fatalf("Encode error: %s", err)
+	}
+	expected := "sha1$$d033e22ae348aeb5660fc2140aec35850c4da997"
+	if encoded != expected {
+		t.Errorf("Expected %q, got %q", expected, encoded)
+	}
+}
+
+func TestSHA1DeprecatedAliasMatches(t *testing.T) {
+	if ErrSaltContainsDollarSing != ErrSaltContainsDollarSign {
+		t.Error("Deprecated alias must point at the canonical error")
+	}
+}

--- a/unchained.go
+++ b/unchained.go
@@ -65,7 +65,7 @@ func IsValidHasher(hasher string) bool {
 }
 
 // IsWeakHasher returns true if the hasher
-// is not recommend by Django, or false otherwise.
+// is not recommended by Django, or false otherwise.
 func IsWeakHasher(hasher string) bool {
 	switch hasher {
 	case
@@ -88,7 +88,6 @@ func IsHasherImplemented(hasher string) bool {
 		Argon2Hasher,
 		BCryptHasher,
 		BCryptSHA256Hasher,
-		// CryptHasher,
 		MD5Hasher,
 		PBKDF2SHA1Hasher,
 		PBKDF2SHA256Hasher,
@@ -139,7 +138,7 @@ func CheckPassword(password, encoded string) (bool, error) {
 
 	switch hasher {
 	case Argon2Hasher:
-		return argon2.NewArgon2Hasher().Verify(password, encoded)
+		return argon2.NewArgon2idHasher().Verify(password, encoded)
 	case BCryptHasher:
 		return bcrypt.NewBCryptHasher().Verify(password, encoded)
 	case BCryptSHA256Hasher:
@@ -169,7 +168,7 @@ func CheckPassword(password, encoded string) (bool, error) {
 //
 // If password is empty then return a concatenation
 // of UnusablePasswordPrefix and a random string.
-// If salt is empty then a randon string is generated.
+// If salt is empty then a random string is generated.
 // BCrypt algorithm ignores salt parameter.
 // If hasher is "default", encode using default hasher.
 func MakePassword(password, salt, hasher string) (string, error) {
@@ -187,7 +186,7 @@ func MakePassword(password, salt, hasher string) (string, error) {
 
 	switch hasher {
 	case Argon2Hasher:
-		return argon2.NewArgon2Hasher().Encode(password, salt)
+		return argon2.NewArgon2idHasher().Encode(password, salt)
 	case BCryptHasher:
 		return bcrypt.NewBCryptHasher().Encode(password, salt)
 	case BCryptSHA256Hasher:

--- a/unchained_test.go
+++ b/unchained_test.go
@@ -13,7 +13,7 @@ func TestMakePasswordDefault(t *testing.T) {
 		t.Fatalf("MakePassword error: %s", err)
 	}
 
-	expected := "pbkdf2_sha256$1000000$1TMOT0Rohg3g$ZRy71wVvUpThAtO+LI/wukwFskI4L/WBwWFkNsH56Ok="
+	expected := "pbkdf2_sha256$1200000$1TMOT0Rohg3g$s0fUiSQszmDp1NrgW33wzSRaciQDtPSyx2QFPqmwZkw="
 
 	if encoded != expected {
 		t.Fatalf("Encoded hash %s does not match %s.", encoded, expected)

--- a/unchained_test.go
+++ b/unchained_test.go
@@ -13,10 +13,19 @@ func TestMakePasswordDefault(t *testing.T) {
 		t.Fatalf("MakePassword error: %s", err)
 	}
 
-	expected := "pbkdf2_sha256$216000$1TMOT0Rohg3g$N+wIigWW4zpxnFBwXTWK1Qt8C9aduBIAayDS2ee8KxI="
+	expected := "pbkdf2_sha256$1000000$1TMOT0Rohg3g$ZRy71wVvUpThAtO+LI/wukwFskI4L/WBwWFkNsH56Ok="
 
 	if encoded != expected {
 		t.Fatalf("Encoded hash %s does not match %s.", encoded, expected)
+	}
+
+	// Round-trip: the hash we just generated must verify with the same password.
+	valid, err := CheckPassword("admin", encoded)
+	if err != nil {
+		t.Fatalf("CheckPassword error: %s", err)
+	}
+	if !valid {
+		t.Fatal("Round-trip verification of generated hash failed.")
 	}
 }
 
@@ -155,6 +164,26 @@ func TestCheckPasswordArgon2(t *testing.T) {
 
 	if !valid {
 		t.Fatal("Password should be valid.")
+	}
+}
+
+func TestMakePasswordArgon2RoundTripsAsArgon2id(t *testing.T) {
+	// MakePassword with the top-level "argon2" identifier should produce
+	// argon2id hashes (matching Django 3.1+ default) that round-trip via
+	// CheckPassword.
+	encoded, err := MakePassword("admin", "", Argon2Hasher)
+	if err != nil {
+		t.Fatalf("MakePassword error: %s", err)
+	}
+	if !strings.Contains(encoded, "$argon2id$") {
+		t.Fatalf("Expected argon2id encoded hash, got: %s", encoded)
+	}
+	valid, err := CheckPassword("admin", encoded)
+	if err != nil {
+		t.Fatalf("CheckPassword error: %s", err)
+	}
+	if !valid {
+		t.Fatal("Round-trip verification of argon2id hash failed.")
 	}
 }
 


### PR DESCRIPTION
Add argon2id support for Django 3.1+ hashes, propagate bcrypt verification errors, raise PBKDF2 defaults, and harden random salt generation. Refresh the README and add broad regression coverage across helpers and hashers.

Constraint: Preserve Django wire compatibility and legacy argon2i behavior for existing callers
Rejected: Keep incidental go.mod/go.sum toolchain churn | unrelated to the password hasher fixes
Confidence: high
Scope-risk: moderate